### PR TITLE
fix: make listener Serializable

### DIFF
--- a/src/main/java/org/vaadin/addons/pulltorefresh/PullToRefreshListener.java
+++ b/src/main/java/org/vaadin/addons/pulltorefresh/PullToRefreshListener.java
@@ -1,5 +1,7 @@
 package org.vaadin.addons.pulltorefresh;
 
-public interface PullToRefreshListener {
+import java.io.Serializable;
+
+public interface PullToRefreshListener extends Serializable {
     void onRefresh();
 }


### PR DESCRIPTION
Listener is store inside Vaadin components, so it need to be Serializable